### PR TITLE
github actions 워크플로우, ECR 추가

### DIFF
--- a/.github/workflows/springboot.yml
+++ b/.github/workflows/springboot.yml
@@ -35,5 +35,4 @@ jobs:
         REPOSITORY: springboot
         IMAGE_TAG: ${{ github.sha }}
       run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
-          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          docker buildx build --platform linux/amd64,linux/arm64 -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -f springboot/Dockerfile ./springboot --push

--- a/.github/workflows/springboot.yml
+++ b/.github/workflows/springboot.yml
@@ -26,13 +26,12 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
 
-    - name: Set up buildx
-      uses: docker/setup-buildx-action@v3
     
     - name: Dokcer Build and Push
       env:
-        REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REPOSITORY: springboot
         IMAGE_TAG: ${{ github.sha }}
       run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t $REGISTRY/$REPOSITORY:$IMAGE_TAG -f springboot/Dockerfile ./springboot --push
+          docker build -t ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }} -f springboot/Dockerfile ./springboot
+          docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/springboot.yml
+++ b/.github/workflows/springboot.yml
@@ -4,9 +4,36 @@ run-name: springboot build - ${{ github.head_ref || github.ref_name }}
 on:
   workflow_dispatch:
 
+# oidc token 인증
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+    
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ secrets.AWS_GITHUB_ACTIONS_ASSUME_ROLE }}
+        aws-region: ap-northeast-2
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    - name: Set up buildx
+      uses: docker/setup-buildx-action@v3
+    
+    - name: Dokcer Build and Push
+      env:
+        REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+        REPOSITORY: springboot
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+          docker buildx build --platform linux/amd64,linux/arm64 -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG

--- a/terraform/share/iam-githubactions.tf
+++ b/terraform/share/iam-githubactions.tf
@@ -1,0 +1,44 @@
+# aws Identity provider 생성 - github
+resource "aws_iam_openid_connect_provider" "githb_actions_oidc_provider" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+# github actions에서 사용할 assume role 생성
+resource "aws_iam_role" "github_actions_role" {
+    name = "githubActionsRole"
+
+    assume_role_policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "${aws_iam_openid_connect_provider.githb_actions_oidc_provider.id}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringLike": {
+                    "token.actions.githubusercontent.com:sub": "${var.allow_repo}"
+                },
+                "StringEquals": {
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}
+
+# ECR에 push할 수 있도록 PowerUser 권한 추가
+resource "aws_iam_role_policy_attachment" "AmazonEC2ContainerRegistryPowerUser" {
+    policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+    role       = aws_iam_role.github_actions_role.name
+}

--- a/terraform/share/variables.tf
+++ b/terraform/share/variables.tf
@@ -1,0 +1,4 @@
+# terraform으로 최초 github actions에서 사용할 assume role 생성할 때, 허용할 repo 지정
+variable "allow_repo" {
+  default = "repo:kyeongjun-dev/sp-labs-prac:*"
+}


### PR DESCRIPTION
# 수정사항
## terraform tf 파일
- github actions에서 사용할 AWS assume role를 terraform으로 생성하도록 수정
- assume role 생성시 특정 repo만 허용하도록 수정 - `terraform/share/variables.tf` 파일에 예시용 기본값 지정

## github actions 워크플로우
- `.github/workflows/springboot.yml`에서 oidc 방식 인증 적용
- assume 방식으로 ECR 로그인 후, 빌드한 springboot 이미지를 push 하도록 수정