### PR TITLE
subnet에 elb 태그 추가, aws-load-balancer-controller policy 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 ### terraform 디렉토리
 - terraform으로 구성한 인프로 소스코드파일 및 README
 - 사용방법은 terraform/README 참고
+
+### 참고사항
+- 생성하는 클러스터 이름은 `dev`로 가정 - subnet tag에 사용

--- a/terraform/01-share/vpc.tf
+++ b/terraform/01-share/vpc.tf
@@ -9,6 +9,16 @@ module "vpc" {
     private_subnets = ["192.168.3.0/24", "192.168.4.0/24"]
     intra_subnets   = ["192.168.5.0/24", "192.168.6.0/24"]
 
+    public_subnet_tags = {
+      "kubernetes.io/cluster/dev" = "shared"
+      "kubernetes.io/role/elb" = "1"
+    }
+
+    private_subnet_tags = {
+      "kubernetes.io/cluster/dev" = "shared"
+      "kubernetes.io/role/internal-elb" = "1"
+    }
+
     enable_nat_gateway = true
     single_nat_gateway = false
     one_nat_gateway_per_az = true

--- a/terraform/04-aws-load-balancer-controller/iam.tf
+++ b/terraform/04-aws-load-balancer-controller/iam.tf
@@ -33,6 +33,7 @@ POLICY
 }
 
 # 다운로드 : curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.7.2/docs/install/iam_policy.json
+# elasticloadbalancing:DescribeListenerAttributes 추가
 resource "aws_iam_policy" "aws_loadbalancer_controller_policy" {
   name        = "AWSLoadBalancerControllerPolicy"
   path        = "/"
@@ -80,7 +81,8 @@ resource "aws_iam_policy" "aws_loadbalancer_controller_policy" {
                     "elasticloadbalancing:DescribeTargetGroupAttributes",
                     "elasticloadbalancing:DescribeTargetHealth",
                     "elasticloadbalancing:DescribeTags",
-                    "elasticloadbalancing:DescribeTrustStores"
+                    "elasticloadbalancing:DescribeTrustStores",
+                    "elasticloadbalancing:DescribeListenerAttributes",
                 ],
                 "Resource": "*"
             },


### PR DESCRIPTION
- public, private subnet에 각각 태그 추가 
  - `kubernetes.io/cluster/dev: shared`
  - `kubernetes.io/role/elb: 1`
  - `kubernetes.io/role/internal-elb: 1`
- aws-load-balancer-controller에서 사용하는 AWS Policy에 elasticloadbalancing:DescribeListenerAttributes 추가